### PR TITLE
allow for formatting the title of a schema property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "name": "@getcrft/jsonizer",
   "author": "CRFT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,10 @@ import uniq from 'lodash/uniq';
 import merge from 'lodash/merge';
 
 export type GeneratorOptions = {
-  formatTitle?: boolean;
+  formatTitle?: (key: string) => string;
 };
 
-export const schemaGenerator = (
-  data: any,
-  options: GeneratorOptions = { formatTitle: true }
-) => {
+export const schemaGenerator = (data: any, options?: GeneratorOptions) => {
   const getType = (o: any) => {
     if (o === null) {
       return 'string';
@@ -33,7 +30,9 @@ export const schemaGenerator = (
 
       for (const key in child) {
         const item = child[key];
-        const title = options.formatTitle ? startCase(key) : key;
+        const title = options?.formatTitle
+          ? options.formatTitle(key)
+          : startCase(key);
         schema.properties[key] = {
           title,
         };

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -262,4 +262,23 @@ describe('Schema Generator', () => {
 
     expect(result).toStrictEqual(expected);
   });
+
+  it('should handle formatting the title', () => {
+    const formatTitle = (key: string) => `New Title - ${key}`;
+    const result = schemaGenerator({ baz: true }, { formatTitle });
+
+    const expected = {
+      type: 'object',
+      required: [],
+      properties: {
+        baz: {
+          title: 'New Title - baz',
+          type: 'boolean',
+          examples: [true],
+        },
+      },
+    };
+
+    expect(result).toStrictEqual(expected);
+  });
 });


### PR DESCRIPTION
Update schemaGenerator to allow for an option to format the title of a property via a callback function